### PR TITLE
オープンソースと配布の非対応を修正

### DIFF
--- a/Assets/scripts/Distribute.cs
+++ b/Assets/scripts/Distribute.cs
@@ -17,7 +17,7 @@ public class Distribute : MonoBehaviour
         int cardCount = 0;
         foreach(int i in hands.Gethand0())
         {
-            GameObject cardCopy = (GameObject)Instantiate(cardPrefab);
+            GameObject cardCopy = Instantiate(cardPrefab);
             CardModel cardModel = cardCopy.GetComponent<CardModel>();
             Vector3 temp;
             float co = cardOffset * cardCount;

--- a/Assets/scripts/Hands.cs
+++ b/Assets/scripts/Hands.cs
@@ -30,7 +30,7 @@ public class Hands : MonoBehaviour
     {
         return grave;
     }
-    public void DeletePair(int num,int player)
+    public void DeletePair(int num,int player)  //num is 1~13
     {
         int count=0;
         int removed=0;
@@ -51,6 +51,7 @@ public class Hands : MonoBehaviour
             }
         }
     }
+
     private void FirstDelete()
     {
         for(int players =0; players < 4; players++)
@@ -92,6 +93,6 @@ public class Hands : MonoBehaviour
     }
 
     // Update is called once per frame
-    
+
 }
 

--- a/Assets/scripts/ShowSource.cs
+++ b/Assets/scripts/ShowSource.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 [RequireComponent(typeof(Hands))]
 public class ShowSource : MonoBehaviour
 {
+    GameObject hand;
     Hands hands;
     public List<int> grave;
     private List<GameObject> sources;
@@ -64,7 +65,6 @@ public class ShowSource : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        hands = GetComponent<Hands>();
 
     }
 
@@ -73,6 +73,8 @@ public class ShowSource : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.Space))
         {
+            hand = GameObject.Find("Hand");
+            hands = hand.GetComponent<Hands>();
             Display();
             //grave = hands.GetGrave();
         }

--- a/Assets/scripts/ZiziDeck.cs
+++ b/Assets/scripts/ZiziDeck.cs
@@ -11,6 +11,11 @@ public class ZiziDeck : MonoBehaviour
         return cards;
     }
 
+    public int GetZizi()
+    {
+        return zizi;
+    }
+
     public void Shuffle()
     {
         if (cards == null)


### PR DESCRIPTION
(GameObject)opensourceで(GameObject)Handと同様にzizideckから手札を取得した結果、この２つで違う手札が用意されてしまった。opensource内では(GameObject)Handを取得して、そこからgraveなどの変数を得ることで、解決された。その他にも見やすくするために少し改変を加えた